### PR TITLE
Disable Interpolation in moduledoc

### DIFF
--- a/lib/cldr/route.ex
+++ b/lib/cldr/route.ex
@@ -1,5 +1,5 @@
 defmodule Cldr.Route do
-  @moduledoc """
+  @moduledoc ~S"""
   Generate localized routes and route helper
   modules.
 
@@ -22,7 +22,7 @@ defmodule Cldr.Route do
   generated that wrap the standard Phoenix helpers to
   supporting generating localised path and URLs.
 
-  ### COnfiguration
+  ### Configuration
 
   A Cldr backend module that configures a `Gettext`
   asosciated backend is required.


### PR DESCRIPTION
```
== Compilation error in file lib/cldr/route.ex ==
** (CompileError) lib/cldr/route.ex:124: undefined function locale/0 (there is no such import)
    (elixir 1.13.4) expanding macro: Kernel.to_string/1
    lib/cldr/route.ex:124: Cldr.Route (module)
    (elixir 1.13.4) expanding macro: Kernel.@/1
    lib/cldr/route.ex:2: Cldr.Route (module)
```